### PR TITLE
Update cspell dictionary

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -19,7 +19,6 @@ rustflags
 rustfmt
 rustup
 SIDREF
-SIGINT
 splitn
 texbinormal
 texcoord


### PR DESCRIPTION
"SIGINT" has been added to the default dictionary: https://github.com/streetsidesoftware/cspell-dicts/commit/1aa70168b464bb75213b8b3e5218ce478dbe1014