### PR TITLE
Fix dead_code warning

### DIFF
--- a/src/collada/mod.rs
+++ b/src/collada/mod.rs
@@ -145,7 +145,7 @@ impl<T> PartialEq<Uri<'_, T>> for &str {
 
 trait ColladaXmlNodeExt<'a, 'input> {
     fn parse_url<T>(&self, name: &str) -> io::Result<Uri<'a, T>>;
-    fn parse_url_opt<T>(&self, name: &str) -> io::Result<Option<Uri<'a, T>>>;
+    // fn parse_url_opt<T>(&self, name: &str) -> io::Result<Option<Uri<'a, T>>>;
 }
 
 impl<'a, 'input> ColladaXmlNodeExt<'a, 'input> for xml::Node<'a, 'input> {
@@ -162,21 +162,21 @@ impl<'a, 'input> ColladaXmlNodeExt<'a, 'input> for xml::Node<'a, 'input> {
         })
     }
 
-    fn parse_url_opt<T>(&self, name: &str) -> io::Result<Option<Uri<'a, T>>> {
-        if let Some(url) = self.attribute(name) {
-            Uri::parse(url).map(Some).map_err(|e| {
-                format_err!(
-                    "{} in {} attribute of <{}> element at {}",
-                    e,
-                    name,
-                    self.tag_name().name(),
-                    self.attr_location(name),
-                )
-            })
-        } else {
-            Ok(None)
-        }
-    }
+    // fn parse_url_opt<T>(&self, name: &str) -> io::Result<Option<Uri<'a, T>>> {
+    //     if let Some(url) = self.attribute(name) {
+    //         Uri::parse(url).map(Some).map_err(|e| {
+    //             format_err!(
+    //                 "{} in {} attribute of <{}> element at {}",
+    //                 e,
+    //                 name,
+    //                 self.tag_name().name(),
+    //                 self.attr_location(name),
+    //             )
+    //         })
+    //     } else {
+    //         Ok(None)
+    //     }
+    // }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
```
error: method `parse_url_opt` is never used
   --> /home/runner/work/mesh-loader/mesh-loader/src/collada/mod.rs:148:8
    |
146 | trait ColladaXmlNodeExt<'a, 'input> {
    |       ----------------- method in this trait
147 |     fn parse_url<T>(&self, name: &str) -> io::Result<Uri<'a, T>>;
148 |     fn parse_url_opt<T>(&self, name: &str) -> io::Result<Option<Uri<'a, T>>>;
    |        ^^^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`
```